### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-vcs-permalinks
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,29 @@ repos:
     rev: v1.4.0
     hooks:
       - id: detect-secrets
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt
+        language: rust
+        pass_filenames: False
+
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test
+        language: rust
+        pass_filenames: False
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy
+        language: rust
+        pass_filenames: False
+
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check
+        language: rust
+        pass_filenames: False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
       - id: detect-private-key
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
         language: rust
         pass_filenames: False
 
-      - id: cargo-test
-        name: cargo test
-        entry: cargo test
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check
         language: rust
         pass_filenames: False
 
@@ -38,8 +38,8 @@ repos:
         language: rust
         pass_filenames: False
 
-      - id: cargo-check
-        name: cargo check
-        entry: cargo check
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test
         language: rust
         pass_filenames: False

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ More APIs to come in the future.
 
 ## Development
 
+After checking out this repository, run the following commands from the root:
+
+* Pre-commit install: `pre-commit install --install-hooks`
+* Pre-commit checks: `pre-commit run --all`
+* Rust tests: `cargo checkmate`
+
+Open a merge request for each new feature, keeping the commits and overall
+diffs as small as possible. Only submit one new feature per merge request.
+
 ## Testing
 
 You can run tests with `cargo test`. You may want to use `cargo watch -x test`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ More APIs to come in the future.
 
 After checking out this repository, run the following commands from the root:
 
+* Install cargo-checkmate: `cargo install cargo-checkmate`
 * Pre-commit install: `pre-commit install --install-hooks`
 * Pre-commit checks: `pre-commit run --all`
 * Rust tests: `cargo checkmate`


### PR DESCRIPTION
Resolves issue #3

Add pre-commit to include checks for syntax errors and secrets across the repository as well as issues in the rust code.

While we could run cargo-checkmate in a similar fashion, it takes a while to run and doesn't show progress in stdout, slowing down commit times.

This means we are missing `cargo audit`, `doc` and `build` in this process. CI will check all of these for us and in the future we may want to incorporate them into pre-commit.